### PR TITLE
fix base32to10 to work on larger input strings

### DIFF
--- a/lib/base32_crockford.ex
+++ b/lib/base32_crockford.ex
@@ -170,7 +170,7 @@ defmodule Base32Crockford do
 
   defp base32to10({char, power}) do
     with {:ok, value} <- dec(char) do
-      value * :math.pow(32, power) |> round
+      value * Integer.pow(32, power)
     end
   end
 


### PR DESCRIPTION
If the input is longer than 204 characters, `:math.pow(32, ...)` throws an `ArithmeticError`.

Test input: 8EB0D7V0BSW915SPF45K8XTEWNAKBJJC48XCDVGYPEMCGYNQ5KDGBM2T0K9105ZMZACDP50TGGYHP07M8B5DM3WNW9P5W4A9R803CG5HJGSYAR0CJZACM06GC3ABAFJPQQCN50X6W8YR0MNAEJ3CC9P7HD7RDFHJ249DDMHPGPY7WG598S68BY7K0BMFY2KBP3TGNE66XS1EWF2C8AZT2821CY8T99